### PR TITLE
Adapt sbgECom library to Zephyr build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,20 @@ else ()
     list(REMOVE_ITEM COMMON_SRC ${PROJECT_SOURCE_DIR}/common/interfaces/sbgInterfaceSerialUnix.c)
 endif()
 
+# Exclude files for zephyr build
+if(__ZEPHYR__)
+    message(STATUS "Excluding files for Zephyr build")
+    file(GLOB_RECURSE COMMON_SRC_REMOVE 
+        ${PROJECT_SOURCE_DIR}/common/interfaces/*.c 
+        ${PROJECT_SOURCE_DIR}/common/debug/*.c
+        ${PROJECT_SOURCE_DIR}/common/network/*.c)
+    list(REMOVE_ITEM COMMON_SRC_REMOVE ${PROJECT_SOURCE_DIR}/common/interfaces/sbgInterface.c) # whitelist
+    list(REMOVE_ITEM COMMON_SRC ${COMMON_SRC_REMOVE})
+    target_link_libraries(${PROJECT_NAME} PRIVATE zephyr_interface)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE __ZEPHYR__)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-maybe-uninitialized)
+endif()
+
 target_sources(${PROJECT_NAME} PRIVATE ${COMMON_SRC} ${ECOM_SRC})
 
 target_include_directories(${PROJECT_NAME}
@@ -150,47 +164,49 @@ endif()
 # Install the main library target
 #
 
-# Export the target so it can be used by other projects
-install(TARGETS ${PROJECT_NAME}
-    EXPORT sbgEComTargets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include)
+if(NOT __ZEPHYR__)
+    # Export the target so it can be used by other projects
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT sbgEComTargets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include)
 
-# Export CMake targets for use in other projects
-install(EXPORT sbgEComTargets
-        FILE sbgEComTargets.cmake
-        NAMESPACE sbgECom::
-        DESTINATION lib/cmake/sbgECom)
+    # Export CMake targets for use in other projects
+    install(EXPORT sbgEComTargets
+            FILE sbgEComTargets.cmake
+            NAMESPACE sbgECom::
+            DESTINATION lib/cmake/sbgECom)
 
-# Create a version file for compatibility checks
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfigVersion.cmake"
-    VERSION 5.3.2276
-    COMPATIBILITY SameMajorVersion
-)
+    # Create a version file for compatibility checks
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfigVersion.cmake"
+        VERSION 5.3.2276
+        COMPATIBILITY SameMajorVersion
+    )
 
-# Create a config file to describe the package
-configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sbgEComConfig.in.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/sbgECom
-)
+    # Create a config file to describe the package
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sbgEComConfig.in.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfig.cmake"
+        INSTALL_DESTINATION lib/cmake/sbgECom
+    )
 
-# Install cmake config  and version files
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfigVersion.cmake"
-    DESTINATION lib/cmake/sbgECom
-)
+    # Install cmake config  and version files
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/sbgEComConfigVersion.cmake"
+        DESTINATION lib/cmake/sbgECom
+    )
 
-# Install header files from common and src directories
-install(DIRECTORY common/
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
+    # Install header files from common and src directories
+    install(DIRECTORY common/
+            DESTINATION include
+            FILES_MATCHING PATTERN "*.h")
 
-install(DIRECTORY src/
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY src/
+            DESTINATION include
+            FILES_MATCHING PATTERN "*.h")
+endif()

--- a/common/platform/sbgPlatform.c
+++ b/common/platform/sbgPlatform.c
@@ -4,7 +4,7 @@
 //----------------------------------------------------------------------//
 //- Include specific header for WIN32 and UNIX platforms               -//
 //----------------------------------------------------------------------//
-#ifdef KERNEL
+#ifdef __ZEPHYR__
 #include <zephyr/kernel.h>
 #elif defined(WIN32)
 #include <windows.h>
@@ -29,7 +29,7 @@ SbgCommonLibOnLogFunc gLogCallback = NULL;
 
 SBG_COMMON_LIB_API uint32_t sbgGetTime(void)
 {
-#ifdef KERNEL
+#ifdef __ZEPHYR__
     return (uint32_t)k_uptime_get();
 #elif defined(WIN32)
     //
@@ -57,7 +57,7 @@ SBG_COMMON_LIB_API uint32_t sbgGetTime(void)
 
 SBG_COMMON_LIB_API void sbgSleep(uint32_t ms)
 {
-#ifdef KERNEL
+#ifdef __ZEPHYR__
     k_msleep(ms);
 #elif defined(WIN32)
     Sleep(ms);

--- a/common/platform/sbgPlatform.c
+++ b/common/platform/sbgPlatform.c
@@ -57,7 +57,9 @@ SBG_COMMON_LIB_API uint32_t sbgGetTime(void)
 
 SBG_COMMON_LIB_API void sbgSleep(uint32_t ms)
 {
-#ifdef WIN32
+#ifdef KERNEL
+    k_msleep(ms);
+#elif defined(WIN32)
     Sleep(ms);
 #else
     struct timespec req;

--- a/common/platform/sbgPlatform.c
+++ b/common/platform/sbgPlatform.c
@@ -4,12 +4,14 @@
 //----------------------------------------------------------------------//
 //- Include specific header for WIN32 and UNIX platforms               -//
 //----------------------------------------------------------------------//
-#ifdef WIN32
-    #include <windows.h>
+#ifdef KERNEL
+#include <zephyr/kernel.h>
+#elif defined(WIN32)
+#include <windows.h>
 #elif defined(__APPLE__)
-    #include <mach/mach_time.h>
+#include <mach/mach_time.h>
 #else
-    #include <unistd.h>
+#include <unistd.h>
 #endif
 
 //----------------------------------------------------------------------//
@@ -19,7 +21,7 @@
 /*!
  * Unique singleton used to log error messages.
  */
-SbgCommonLibOnLogFunc   gLogCallback = NULL;
+SbgCommonLibOnLogFunc gLogCallback = NULL;
 
 //----------------------------------------------------------------------//
 //- Public functions                                                   -//
@@ -27,13 +29,15 @@ SbgCommonLibOnLogFunc   gLogCallback = NULL;
 
 SBG_COMMON_LIB_API uint32_t sbgGetTime(void)
 {
-#ifdef WIN32
+#ifdef KERNEL
+    return (uint32_t)k_uptime_get();
+#elif defined(WIN32)
     //
     // Return the current time in ms
     //
     return clock() / (CLOCKS_PER_SEC / 1000);
 #elif defined(__APPLE__)
-    mach_timebase_info_data_t   timeInfo;
+    mach_timebase_info_data_t timeInfo;
     mach_timebase_info(&timeInfo);
 
     //
@@ -56,9 +60,9 @@ SBG_COMMON_LIB_API void sbgSleep(uint32_t ms)
 #ifdef WIN32
     Sleep(ms);
 #else
-    struct timespec          req;
-    struct timespec          rem;
-    int                      ret;
+    struct timespec req;
+    struct timespec rem;
+    int ret;
 
     req.tv_sec = ms / 1000;
     req.tv_nsec = (ms % 1000) * 1000000L;
@@ -89,8 +93,8 @@ SBG_COMMON_LIB_API void sbgCommonLibSetLogCallback(SbgCommonLibOnLogFunc logCall
 
 SBG_COMMON_LIB_API void sbgPlatformDebugLogMsg(const char *pFileName, const char *pFunctionName, uint32_t line, const char *pCategory, SbgDebugLogType logType, SbgErrorCode errorCode, const char *pFormat, ...)
 {
-    char        errorMsg[SBG_CONFIG_LOG_MAX_SIZE];
-    va_list     args;
+    char errorMsg[SBG_CONFIG_LOG_MAX_SIZE];
+    va_list args;
 
     assert(pFileName);
     assert(pFunctionName);
@@ -127,19 +131,19 @@ SBG_COMMON_LIB_API void sbgPlatformDebugLogMsg(const char *pFileName, const char
         switch (logType)
         {
         case SBG_DEBUG_LOG_TYPE_ERROR:
-            fprintf(stderr, "*ERR * %s(%"PRIu32"): %s - %s\n\r", pFunctionName, line, sbgErrorCodeToString(errorCode), errorMsg);
+            fprintf(stderr, "*ERR * %s(%" PRIu32 "): %s - %s\n\r", pFunctionName, line, sbgErrorCodeToString(errorCode), errorMsg);
             break;
         case SBG_DEBUG_LOG_TYPE_WARNING:
-            fprintf(stderr, "*WARN* %s(%"PRIu32"): %s - %s\n\r", pFunctionName, line, sbgErrorCodeToString(errorCode), errorMsg);
+            fprintf(stderr, "*WARN* %s(%" PRIu32 "): %s - %s\n\r", pFunctionName, line, sbgErrorCodeToString(errorCode), errorMsg);
             break;
         case SBG_DEBUG_LOG_TYPE_INFO:
-            fprintf(stderr, "*INFO* %s(%"PRIu32"): %s\n\r", pFunctionName, line, errorMsg);
+            fprintf(stderr, "*INFO* %s(%" PRIu32 "): %s\n\r", pFunctionName, line, errorMsg);
             break;
         case SBG_DEBUG_LOG_TYPE_DEBUG:
-            fprintf(stderr, "*DBG * %s(%"PRIu32"): %s\n\r", pFunctionName, line, errorMsg);
+            fprintf(stderr, "*DBG * %s(%" PRIu32 "): %s\n\r", pFunctionName, line, errorMsg);
             break;
         default:
-            fprintf(stderr, "*UKNW* %s(%"PRIu32"): %s\n\r", pFunctionName, line, errorMsg);
+            fprintf(stderr, "*UKNW* %s(%" PRIu32 "): %s\n\r", pFunctionName, line, errorMsg);
             break;
         }
     }

--- a/common/string/sbgString.c
+++ b/common/string/sbgString.c
@@ -1690,7 +1690,7 @@ SBG_COMMON_LIB_API SbgErrorCode sbgStringFromFloat(SbgString *pString, float val
         size_t                           oldCapacity;
         int                              result;
 
-        result = snprintf(pString->pBuffer, pString->capacity, "%f", value);
+        result = snprintf(pString->pBuffer, pString->capacity, "%f", (double) value);
 
         assert(result >= 0);
 
@@ -1704,7 +1704,7 @@ SBG_COMMON_LIB_API SbgErrorCode sbgStringFromFloat(SbgString *pString, float val
         {
             if (length >= oldCapacity)
             {
-                snprintf(pString->pBuffer, pString->capacity, "%f", value);
+                snprintf(pString->pBuffer, pString->capacity, "%f", (double) value);
             }
 
             pString->length = (size_t)length;


### PR DESCRIPTION
Code:
- Add Zephyr clock and sleep in `sbgPlatform.c`
- Add explicit double conversions to avoid warnings

CMake:
- Remove unused interface sources
- Link Zephyr library
- Remove warnings
- Add __ZEPHYR__ definition (optional, for clarity)